### PR TITLE
DOCTYPEs

### DIFF
--- a/lib/xml-writer.js
+++ b/lib/xml-writer.js
@@ -27,6 +27,8 @@ function XMLWriter(indent, callback) {
     this.attribute = 0;
     this.texts = 0;
     this.comment = 0;
+    this.dtd = 0;
+    this.root = '';
     this.pi = 0;
     this.cdata = 0;
     this.started_write = false;
@@ -115,6 +117,7 @@ XMLWriter.prototype = {
     startElement : function (name) {
         name = strval(name);
         if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
+        if (this.tags === 0 && this.root && this.root !== name) throw Error('Invalid Parameter');
         if (this.attributes) this.endAttributes();
         ++this.tags;
         this.texts = 0;
@@ -264,6 +267,41 @@ XMLWriter.prototype = {
         return this;
     },
 
+    writeDocType : function (name, pubid, sysid, subset) {
+        return this.startDocType(name, pubid, sysid, subset).endDocType()
+    },
+
+    startDocType : function (name, pubid, sysid, subset) {
+        if (this.dtd || this.tags) return this;
+
+        name = strval(name);
+        pubid = pubid ? strval(pubid) : pubid;
+        sysid = sysid ? strval(sysid) : sysid;
+        subset = subset ? strval(subset) : subset;
+
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
+        if (pubid && !pubid.match(/^[\w\-][\w\s\-\/\+\:\.]*/)) throw Error('Invalid Parameter');
+        if (sysid && !sysid.match(/^[\w\.][\w\-\/\\\:\.]*/)) throw Error('Invalid Parameter');
+        if (subset && !subset.match(/[\w\s\<\>\+\.\!\#\-\?\*\,\(\)\|]*/)) throw Error('Invalid Parameter');
+
+        pubid = pubid ? ' PUBLIC "' + pubid + '"' : (sysid) ? ' SYSTEM' : '';
+        sysid = sysid ? ' "' + sysid + '"' : '';
+        subset = subset ? ' [' + subset + ']': '';
+
+        if (this.started_write) this.indenter();
+        this.write('<!DOCTYPE ', name, pubid, sysid, subset);
+        this.root = name;
+        this.dtd = 1;
+        this.started_write = true;
+        return this;
+    },
+
+    endDocType : function () {
+        if (!this.dtd) return this;
+        this.write('>');
+        return this;
+    },
+
     writePI : function (name, content) {
         return this.startPI(name).text(content).endPI()
     },
@@ -279,18 +317,18 @@ XMLWriter.prototype = {
         this.started_write = true;
         return this;
     },
-    
+
     endPI : function () {
         if (!this.pi) return this;
         this.write('?>');
         this.pi = 0;
         return this;
     },
-    
+
     writeCData : function (content) {
         return this.startCData().text(content).endCData();
     },
-    
+
     startCData : function () {
         if (this.cdata) return this;
         if (this.attributes) this.endAttributes();
@@ -300,7 +338,7 @@ XMLWriter.prototype = {
         this.started_write = true;
         return this;
     },
-    
+
     endCData : function () {
         if (!this.cdata) return this;
         this.write(']]>');

--- a/test/doctype.js
+++ b/test/doctype.js
@@ -1,0 +1,38 @@
+var XMLWriter = require('../');
+exports['setUp'] = function (callback) {
+    this.xw = new XMLWriter;
+    callback();
+};
+exports['t01'] = function (test) {
+    this.xw.writeDocType('foo');
+    test.equal(this.xw.toString(), '<!DOCTYPE foo>');
+    test.done();
+};
+exports['t02'] = function (test) {
+    this.xw.writeDocType('foo', null, 'http://localhost/foo');
+    test.equal(this.xw.toString(), '<!DOCTYPE foo SYSTEM "http://localhost/foo">');
+    test.done();
+};
+exports['t03'] = function (test) {
+    this.xw.writeDocType('foo', null, null, '<!ELEMENT foo><!ATTLIST foo DocVersion (1) #REQUIRED>');
+    test.equal(this.xw.toString(), '<!DOCTYPE foo [<!ELEMENT foo><!ATTLIST foo DocVersion (1) #REQUIRED>]>');
+    test.done();
+};
+exports['t04'] = function (test) {
+    this.xw.writeDocType('html', "-//W3C//DTD XHTML 1.1//EN", "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd");
+    test.equal(this.xw.toString(), '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">');
+    test.done();
+};
+exports['t05'] = function (test) {
+    test.throws(function(){
+        this.xw.writeDocType('foo', null, null, null);
+        this.xw.startElement('bar');
+    });
+    test.done();
+};
+exports['t06'] = function (test) {
+    this.xw.startElement('foo');
+    this.xw.writeDocType('foo', null, null, null);
+    test.equal(this.xw.toString(), '<foo/>');
+    test.done();
+};


### PR DESCRIPTION
Added support for DOCTYPE declaration (writeDocType) as well as unit test: doctype.js

I'm probably missing some legal characters in the regex tests for pubid, sysid & subset values.  I put them together based on examples I found on the web.
