### PR TITLE
writing plain text for CData

### DIFF
--- a/lib/xml-writer.js
+++ b/lib/xml-writer.js
@@ -240,7 +240,7 @@ XMLWriter.prototype = {
         } else if (this.attributes && !this.attribute) {
             this.endAttributes();
         } 
-        if (this.comment) {
+        if (this.comment || this.cdata) {
             this.write(content);
         }
         else {


### PR DESCRIPTION
The contents inside CData are escaped. I changed this to plain text.
