### PR TITLE
Adding a way to specify the indentation string to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Output:
 	<?xml version="1.0"?>
 	<root foo="value">Some content</root>
 
-Tip: If you want your XML **indented** use `new XMLWriter(true)`.
+Tip: If you want your XML **indented** use `new XMLWriter(true)` or `new XMLWriter('\t')`, for instance, if you want to use a custom string for indentation.
 
 ## Chaining
 ```javascript
@@ -104,7 +104,7 @@ Use [nodeunit](https://github.com/caolan/nodeunit) to run the tests.
 
 ## Generic
 
-### constructor XMLWriter(Boolean indent, Function writer(string, encoding))
+### constructor XMLWriter(Boolean|String indent, Function writer(string, encoding))
 Create an new writer
 
 ### text(String content)

--- a/lib/xml-writer.js
+++ b/lib/xml-writer.js
@@ -27,6 +27,7 @@ function XMLWriter(indent, callback) {
 
     this.name_regex = /[_:A-Za-z][-._:A-Za-z0-9]*/;
     this.indent = indent ? true : false;
+    this.indentString = this.indent && typeof indent === 'string' ? indent : '    ';
     this.output = '';
     this.stack = [];
     this.tags = 0;
@@ -61,7 +62,7 @@ XMLWriter.prototype = {
       if (this.indent) {
         this.write('\n');
         for (var i = 1; i < this.tags; i++) {
-          this.write('    ');
+          this.write(this.indentString);
         }
       }
     },


### PR DESCRIPTION
Hello `node-xml-writer`. Just a PR to propose a feature letting the user specify an indentation string if they need to.

```j
// For instance:
new XMLWriter('\t');
```

I am unclear where to add relevant unit tests however and I can add them if you find this PR useful.