### PR TITLE
Add parameter name to 'Invalid parameter' error message

### DIFF
--- a/lib/xml-writer.js
+++ b/lib/xml-writer.js
@@ -124,8 +124,8 @@ XMLWriter.prototype = {
 
     startElement : function (name) {
         name = strval(name);
-        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
-        if (this.tags === 0 && this.root && this.root !== name) throw Error('Invalid Parameter');
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter: name');
+        if (this.tags === 0 && this.root && this.root !== name) throw Error('Invalid Parameter: name');
         if (this.attributes) this.endAttributes();
         ++this.tags;
         this.texts = 0;
@@ -146,8 +146,8 @@ XMLWriter.prototype = {
         prefix = strval(prefix);
         name = strval(name);
 
-        if (!prefix.match(this.name_regex)) throw Error('Invalid Parameter');
-        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
+        if (!prefix.match(this.name_regex)) throw Error('Invalid Parameter: prefix');
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter: name');
         if (this.attributes) this.endAttributes();
         ++this.tags;
         this.texts = 0;
@@ -223,7 +223,7 @@ XMLWriter.prototype = {
 
     startAttribute : function (name) {
         name = strval(name);
-        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter: name');
         if (!this.attributes && !this.pi) return this;
         if (this.attribute) return this;
         this.attribute = 1;
@@ -234,8 +234,8 @@ XMLWriter.prototype = {
         prefix = strval(prefix);
         name = strval(name);
 
-        if (!prefix.match(this.name_regex)) throw Error('Invalid Parameter');
-        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
+        if (!prefix.match(this.name_regex)) throw Error('Invalid Parameter: prefix');
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter: name');
         if (!this.attributes && !this.pi) return this;
         if (this.attribute) return this;
         this.attribute = 1;
@@ -311,10 +311,10 @@ XMLWriter.prototype = {
         sysid = sysid ? strval(sysid) : sysid;
         subset = subset ? strval(subset) : subset;
 
-        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
-        if (pubid && !pubid.match(/^[\w\-][\w\s\-\/\+\:\.]*/)) throw Error('Invalid Parameter');
-        if (sysid && !sysid.match(/^[\w\.][\w\-\/\\\:\.]*/)) throw Error('Invalid Parameter');
-        if (subset && !subset.match(/[\w\s\<\>\+\.\!\#\-\?\*\,\(\)\|]*/)) throw Error('Invalid Parameter');
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter: name');
+        if (pubid && !pubid.match(/^[\w\-][\w\s\-\/\+\:\.]*/)) throw Error('Invalid Parameter: pubid');
+        if (sysid && !sysid.match(/^[\w\.][\w\-\/\\\:\.]*/)) throw Error('Invalid Parameter: sysid');
+        if (subset && !subset.match(/[\w\s\<\>\+\.\!\#\-\?\*\,\(\)\|]*/)) throw Error('Invalid Parameter: subset');
 
         pubid = pubid ? ' PUBLIC "' + pubid + '"' : (sysid) ? ' SYSTEM' : '';
         sysid = sysid ? ' "' + sysid + '"' : '';
@@ -340,7 +340,7 @@ XMLWriter.prototype = {
 
     startPI : function (name) {
         name = strval(name);
-        if (!name.match(this.name_regex)) throw Error('Invalid Parameter');
+        if (!name.match(this.name_regex)) throw Error('Invalid Parameter: name');
         if (this.pi) return this;
         if (this.attributes) this.endAttributes();
         if (this.started_write) this.indenter();


### PR DESCRIPTION
Print out which parameter is invalid to provide more informative error messages.